### PR TITLE
Enable 10s auto reset after scan

### DIFF
--- a/frontend/main.html
+++ b/frontend/main.html
@@ -93,11 +93,24 @@
     const offData       = document.getElementById('off-data');
     const btn           = document.getElementById('capture-btn');
 
+    let resetTimer;
+    function resetUI() {
+      [barcodeList,logoList,textList,webEntityList,labelList,objectList]
+        .forEach(ul => ul.innerHTML = '');
+      aiPrompt.textContent      = '';
+      aiResponse.textContent    = '';
+      finalTerm.textContent     = 'Esperando captura…';
+      pipelineSummary.textContent = '';
+      offStatus.textContent     = '';
+      offData.textContent       = '';
+    }
+
     navigator.mediaDevices.getUserMedia({ video:{ facingMode:'environment' } })
       .then(s => video.srcObject = s)
       .catch(e => alert('Error cámara: '+e.message));
 
     btn.onclick = () => {
+      clearTimeout(resetTimer);
       const ctx = canvas.getContext('2d');
       canvas.width  = video.videoWidth;
       canvas.height = video.videoHeight;
@@ -156,9 +169,12 @@
             offData.textContent   = '';
           }
 
+          resetTimer = setTimeout(resetUI, 10000);
+
         } catch(err) {
           finalTerm.textContent = 'Error';
           alert('Error: '+err.message);
+          resetTimer = setTimeout(resetUI, 10000);
         }
       }, 'image/jpeg');
     };


### PR DESCRIPTION
## Summary
- implement UI reset timer in frontend

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68629db2912883318073822ff8a3a710