### PR TITLE
feat: run backend and frontend from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Este proyecto detecta productos alimenticios usando una foto. El backend usa Goo
 
 1. Copia `.env.example` a `backend/.env` y completa las variables necesarias.
 2. Coloca tus credenciales de Google Vision en `backend/credentials/google-vision.json` (revisa `backend/credentials/README.md`).
-3. Instala dependencias en `backend`:
+3. Instala dependencias desde la raíz del proyecto:
    ```bash
    npm install
    ```
 
 ## Uso
 
-Arranca el servidor con:
+Levanta el backend y un servidor simple para el frontend con:
 ```bash
-npm start --prefix backend
+npm run dev
 ```
-Abre `frontend/main.html` en un navegador para probar la aplicación.
+Luego abre `http://127.0.0.1:8080/main.html` en un navegador para probar la aplicación.
 
 ## Variables de entorno
 
@@ -25,5 +25,3 @@ Revisa `backend/.env.example` para conocer todas las variables necesarias:
 - `PORT` puerto del servidor.
 - `OPENAI_API_KEY` clave de API para OpenAI.
 - `OPENFOODFACTS_PRODUCT_URL` y `OPENFOODFACTS_SEARCH_URL` URLs de la API de OpenFoodFacts.
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "product-scanner",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "product-scanner",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm --prefix backend install --silent",
+    "dev:backend": "npm --prefix backend run dev --silent",
+    "dev:frontend": "live-server frontend --quiet",
+    "dev": "concurrently --kill-others --raw \"npm run dev:backend\" \"npm run dev:frontend\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "live-server": "^1.2.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json with scripts to install backend and run both services
- remove stale lock file and document new single-command workflow

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/concurrently)*
- `npm test` *(fails: Missing script: "test")*
- `npm run dev` *(fails: concurrently: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a858d1dbf883318af62f82209a2661