### PR TITLE
feat: simplify root scripts for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este proyecto detecta productos alimenticios usando una foto. El backend usa Goo
 
 1. Copia `.env.example` a `backend/.env` y completa las variables necesarias.
 2. Coloca tus credenciales de Google Vision en `backend/credentials/google-vision.json` (revisa `backend/credentials/README.md`).
-3. Instala dependencias desde la raíz del proyecto:
+3. Instala las dependencias desde la raíz del proyecto. Gracias a [npm workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) esto también instalará las del backend:
    ```bash
    npm install
    ```

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "product-scanner",
   "private": true,
+  "workspaces": ["backend"],
   "scripts": {
-    "postinstall": "npm --prefix backend install --silent",
-    "dev:backend": "npm --prefix backend run dev --silent",
+    "dev:backend": "node backend/node_modules/nodemon/bin/nodemon.js --quiet backend/index.js",
     "dev:frontend": "live-server frontend --quiet",
     "dev": "concurrently --kill-others --raw \"npm run dev:backend\" \"npm run dev:frontend\""
   },


### PR DESCRIPTION
## Summary
- install backend dependencies via npm workspaces
- run backend dev server using nodemon without extra npm commands

## Testing
- `npm install --workspaces=false --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/concurrently)*
- `npm test` *(fails: Missing script: "test" [ERR])*
- `npm run dev` *(fails: concurrently: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a859fefd588331af9f2b926bcbe67b