### PR TITLE
chore: simplify dev startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/
 backend/.env
 backend/credentials/google-vision.json

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon index.js"
+    "dev": "nodemon --quiet index.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "workspaces": ["backend"],
   "scripts": {
-    "dev:backend": "node backend/node_modules/nodemon/bin/nodemon.js --quiet backend/index.js",
-    "dev:frontend": "live-server frontend --quiet",
-    "dev": "concurrently --kill-others --raw \"npm run dev:backend\" \"npm run dev:frontend\""
+    "dev": "concurrently --kill-others --raw \"npm --workspace backend --silent run dev\" \"live-server frontend --quiet\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Summary
- run backend and frontend together using workspaces with minimal logs
- quiet backend nodemon invocation
- ignore all node_modules directories

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/concurrently)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a85d3d1e848331b20770f9de3af06f