### PR TITLE
Handle sample image via canvas for upload

### DIFF
--- a/frontend/main.html
+++ b/frontend/main.html
@@ -151,7 +151,16 @@
       try {
         const res = await fetch('/examples/test-image.png');
         const blob = await res.blob();
-        upload(blob);
+        const img = new Image();
+        img.onload = () => {
+          const ctx = canvas.getContext('2d');
+          canvas.width = img.width;
+          canvas.height = img.height;
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          URL.revokeObjectURL(img.src);
+          canvas.toBlob(upload, 'image/jpeg');
+        };
+        img.src = URL.createObjectURL(blob);
       } catch(err) {
         results.innerHTML = '<p>Error</p>';
         alert('Error: '+err.message);


### PR DESCRIPTION
## Summary
- Render the example PNG into a canvas and convert to JPEG before sending to the backend to avoid unsupported format errors

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm --workspace backend test` *(fails: Missing script "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9365f6ec833182bae13f24137879